### PR TITLE
Find the lenght of longest sequence of '1's in the binary representation of a number. We are allowed to flip only one zero bit to 1.

### DIFF
--- a/Extensions/StringExtension.cs
+++ b/Extensions/StringExtension.cs
@@ -1,7 +1,5 @@
 namespace Playground.Extensions
 {
-    using System;
-    using System.Collections.Generic;
     using System.Text;
 
     public static class StringExtension

--- a/Problems/FlipBit.cs
+++ b/Problems/FlipBit.cs
@@ -1,0 +1,46 @@
+namespace Playground.Problems
+{
+    using System;
+
+    public static class FlipBit
+    {
+        public static int GetLongestSequenceOfOnesWithSingleFlip(int n)
+        {
+            return FlipBit.GetLongestSequenceOfOnesWithSingleFlip((uint)n);
+        }
+        
+        // If we try to right shift a signed integer the high order empty bits are signed to the sign bit.
+        // i.e. -1 >> 1 == -1. Thus it is better to cast to uint before right shifting, if the desired behaviour
+        // is to fill the high order bits with zeroes.
+        public static int GetLongestSequenceOfOnesWithSingleFlip(uint n)
+        {
+            if (n == 0)
+            {
+                return 1;
+            }
+
+            var max1s = 1;
+            var cur1s = 0;
+            var postZero1s = 0;
+            while (n != 0)
+            {
+                if ((n & 1) == 1)
+                {
+                    cur1s++;
+                    postZero1s++;
+                    max1s = Math.Max(cur1s, max1s);
+                }
+                else
+                {
+                    cur1s = postZero1s + 1;
+                    postZero1s = 0;
+                    max1s = Math.Max(cur1s, max1s);
+                }
+
+                n >>= 1;
+            }
+
+            return max1s;
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,18 +1,15 @@
 namespace Playground
 {
     using System;
-    using System.Collections.Generic;
-    using Playground.Extensions;
-    using Playground.DynamicProgramming;
+    using Playground.Problems;
 
     public static class Program
     {
         public static void Main()
         {
-            var inputSet = new[] {1,2,3,4,5,6,7,60,-6,-5,-4,-3,-2,-1};
-            var subSet = new SubSetSum();
-            var sum = 10;
-            subSet.SubSetWithSum(inputSet, sum).WriteLine();
+            var binaryString = "111101111010010110111";
+            var n = Convert.ToInt32(binaryString, 2);
+            var result = FlipBit.GetLongestSequenceOfOnesWithSingleFlip(n);
         }
     }
 }


### PR DESCRIPTION
E.g.
111011011101110100

The answer is 7.
